### PR TITLE
issue #8 - made sure charset is always specified in string -> byte conversions

### DIFF
--- a/src/main/java/io/proximax/sdk/model/transaction/IdGenerator.java
+++ b/src/main/java/io/proximax/sdk/model/transaction/IdGenerator.java
@@ -19,6 +19,7 @@ package io.proximax.sdk.model.transaction;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +47,7 @@ public class IdGenerator {
       ByteBuffer.wrap(parentIdBytes).put(parentId.toByteArray());
       ArrayUtils.reverse(parentIdBytes);
       // bytes from the mosaic name
-      byte[] nameBytes = name.getBytes();
+      byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
       // get the ID
       return toBigInteger(IdGenerator::maskNamespace, parentIdBytes, nameBytes);
    }

--- a/src/test/java/io/proximax/sdk/model/transaction/MessageFactoryTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/MessageFactoryTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
 import io.proximax.core.crypto.KeyPair;
@@ -20,11 +22,11 @@ public class MessageFactoryTest {
 
     @Test
     public void shouldCreatePlainMessage() {
-        final Message message = MessageFactory.createMessage(MessageType.PLAIN.getCode(), "test-message".getBytes());
+        final Message message = MessageFactory.createMessage(MessageType.PLAIN.getCode(), "test-message".getBytes(StandardCharsets.UTF_8));
 
         assertThat(message, is(notNullValue()));
         assertThat(message, is(instanceOf(PlainMessage.class)));
-        assertThat(message.getEncodedPayload(), is("test-message".getBytes()));
+        assertThat(message.getEncodedPayload(), is("test-message".getBytes(StandardCharsets.UTF_8)));
         assertThat(message.getPayload(), is("test-message"));
         assertThat(message.getTypeCode(), is(MessageType.PLAIN.getCode()));
     }


### PR DESCRIPTION
utf-8 is now used every time when string is converted to byte array