### PR TITLE
Issue #65 - Use of account alias in transfers

### DIFF
--- a/src/e2e/java/io/proximax/sdk/E2EAccountTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EAccountTest.java
@@ -109,6 +109,7 @@ class E2EAccountTest extends E2EBaseTest {
       logger.info("Waiting for  confirmation");
       listener.confirmed(acct.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst();
       // now check for the block via GET
+      sleepForAWhile();
       AccountProperties aps = accountHttp.getAccountProperties(acct.getAddress())
             .timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst();
       testAccountPropertiesOnSimpleAccount(aps, allowedMosaic);

--- a/src/e2e/java/io/proximax/sdk/E2EAggregateTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EAggregateTest.java
@@ -174,6 +174,7 @@ public class E2EAggregateTest extends E2EBaseTest {
       sendMosaic(seedAccount, alice.getAddress(), NetworkCurrencyMosaic.createRelative(BigInteger.ONE));
       sendMosaic(seedAccount, bob.getAddress(), new Mosaic(mosaicY, BigInteger.TEN));
       sendMosaic(seedAccount, mike.getAddress(), NetworkCurrencyMosaic.createRelative(BigInteger.ONE));
+      sleepForAWhile();
       logger.info("Escrow between {}, {} and {}", alice, bob, mike);
       // send mosaic X from alice to bob
       TransferTransaction aliceToBob = TransferTransaction.create(getDeadline(),
@@ -321,6 +322,7 @@ public class E2EAggregateTest extends E2EBaseTest {
       // bob wait for cosignature
       listener.confirmed(bob.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst();
       // test that alice has 10M X and 10 Y
+      sleepForAWhile();
       List<Mosaic> aliceMosaics = accountHttp.getAccountInfo(alice.getAddress()).blockingFirst().getMosaics();
       assertEquals(2, aliceMosaics.size());
       aliceMosaics.forEach(mosaic -> {

--- a/src/e2e/java/io/proximax/sdk/E2EAliasTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EAliasTest.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import io.proximax.core.crypto.KeyPair;
 import io.proximax.sdk.model.account.Account;
 import io.proximax.sdk.model.alias.AliasAction;
+import io.proximax.sdk.model.mosaic.Mosaic;
 import io.proximax.sdk.model.mosaic.MosaicId;
 import io.proximax.sdk.model.mosaic.MosaicNames;
 import io.proximax.sdk.model.mosaic.MosaicNonce;
@@ -41,9 +42,11 @@ import io.proximax.sdk.model.mosaic.MosaicProperties;
 import io.proximax.sdk.model.namespace.NamespaceId;
 import io.proximax.sdk.model.transaction.AliasTransaction;
 import io.proximax.sdk.model.transaction.MosaicDefinitionTransaction;
+import io.proximax.sdk.model.transaction.PlainMessage;
 import io.proximax.sdk.model.transaction.RegisterNamespaceTransaction;
 import io.proximax.sdk.model.transaction.SignedTransaction;
 import io.proximax.sdk.model.transaction.Transaction;
+import io.proximax.sdk.model.transaction.TransferTransaction;
 import io.reactivex.Observable;
 
 /**
@@ -78,7 +81,7 @@ public class E2EAliasTest extends E2EBaseTest {
 
    @AfterAll
    void closeDown() {
-
+      returnAllToSeed(account);
    }
    
    @Test
@@ -149,4 +152,15 @@ public class E2EAliasTest extends E2EBaseTest {
       assertEquals(ROOT_NAME+"."+CHILD1_NAME, name.getNames().get(0));
    }
    
+   @Test
+   void test05TransferUsingAliases() {
+      transactionHttp.announce(TransferTransaction.create(getDeadline(),
+            accNamespaceId,
+            Arrays.asList(new Mosaic(new NamespaceId("cat.currency"), BigInteger.valueOf(1_000_000))),
+            PlainMessage.Empty,
+            getNetworkType()).signWith(seedAccount)).blockingFirst();
+      logger.info("made transfer. {}",
+            listener.confirmed(seedAccount.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS)
+                  .blockingFirst());
+   }
 }

--- a/src/e2e/java/io/proximax/sdk/E2EMetadataTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EMetadataTest.java
@@ -102,6 +102,7 @@ public class E2EMetadataTest extends E2EBaseTest {
       logger.info("Meta added to mosaic. {}",
             listener.confirmed(seedAccount.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst());
       // check the meta
+      sleepForAWhile();
       Metadata meta = metadataHttp.getMetadata(id).blockingFirst();
       checkMeta(meta, MetadataType.MOSAIC, new Field("tono", "mosaic"));
       // add to the list of existing metadata items
@@ -129,6 +130,7 @@ public class E2EMetadataTest extends E2EBaseTest {
       logger.info("Meta added to namespace. {}",
             listener.confirmed(seedAccount.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst());
       // check the meta
+      sleepForAWhile();
       Metadata meta = metadataHttp.getMetadata(rootId).blockingFirst();
       checkMeta(meta, MetadataType.NAMESPACE, new Field("tono", "namespace"));
       // add to the list of existing metadata items
@@ -137,6 +139,7 @@ public class E2EMetadataTest extends E2EBaseTest {
 
    @Test
    void testBulkRequest() {
+      sleepForAWhile();
       assertEquals(3, metadataHttp.getMetadata(metaIds).count().blockingGet());
    }
    

--- a/src/e2e/java/io/proximax/sdk/E2EMosaicTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EMosaicTest.java
@@ -98,6 +98,7 @@ public class E2EMosaicTest extends E2EBaseTest {
       logger.info("Supply changed. {}",
             listener.confirmed(seedAccount.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst());
       // verify that mosaic looks fine
+      sleepForAWhile();
       MosaicInfo info = mosaicHttp.getMosaic(id).blockingFirst();
       assertEquals(BigInteger.TEN, info.getSupply());
    }

--- a/src/e2e/java/io/proximax/sdk/E2EMultisigTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EMultisigTest.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.proximax.core.crypto.KeyPair;
-import io.proximax.sdk.gen.buffers.*;
 import io.proximax.sdk.model.account.Account;
 import io.proximax.sdk.model.account.MultisigAccountGraphInfo;
 import io.proximax.sdk.model.account.MultisigAccountInfo;
@@ -335,6 +334,7 @@ public class E2EMultisigTest extends E2EBaseTest {
    void test04CosignNewCosignatory() {
       logger.info("Going to cosign the addition of cosignatory");
       cosignMultisigTransaction();
+      sleepForAWhile();
       testMultisigAccount(multisigAccount, true, 2, 1, 3, 2);
    }
 
@@ -356,6 +356,7 @@ public class E2EMultisigTest extends E2EBaseTest {
       // verify that account is multisig
       logger.info("request o create multilevel multisig confirmed: {}",
             listener.confirmed(multiMultisigAccount.getAddress()).timeout(getTimeoutSeconds(), TimeUnit.SECONDS).blockingFirst());
+      sleepForAWhile();
       testMultisigAccount(multiMultisigAccount, true, 1, 1, 2, 3);
    }
    

--- a/src/e2e/java/io/proximax/sdk/E2ETransferTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2ETransferTest.java
@@ -142,7 +142,6 @@ public class E2ETransferTest extends E2EBaseTest {
     * @param to target address for the transfer
     * @param mosaic mosaic to transfer
     * @param message message for the transfer
-    * @return transaction announce response message
     * @throws InterruptedException
     * @throws ExecutionException
     */

--- a/src/main/java/io/proximax/sdk/infrastructure/TransactionMapping.java
+++ b/src/main/java/io/proximax/sdk/infrastructure/TransactionMapping.java
@@ -236,7 +236,7 @@ class TransferTransactionMapping extends TransactionMapping {
                 extractTransactionVersion(version),
                 deadline,
                 extractFee(transaction),
-                Address.createFromEncoded(transaction.get("recipient").getAsString()),
+                Recipient.from(Address.createFromEncoded(transaction.get("recipient").getAsString())),
                 mosaics,
                 message,
                 transaction.get("signature").getAsString(),

--- a/src/main/java/io/proximax/sdk/model/namespace/NamespaceId.java
+++ b/src/main/java/io/proximax/sdk/model/namespace/NamespaceId.java
@@ -30,59 +30,63 @@ import io.proximax.sdk.utils.dto.UInt64Utils;
  * @since 1.0
  */
 public class NamespaceId implements UInt64Id {
-    private final BigInteger id;
-    private final Optional<String> fullName;
+   private final BigInteger id;
+   private final Optional<String> fullName;
 
-    /**
-     * Create NamespaceId from namespace string name (ex: nem or domain.subdom.subdome)
-     *
-     * @param id string representing domain levels
-     */
-    public NamespaceId(String id) {
-        this.id = IdGenerator.generateNamespaceId(id);
-        this.fullName = Optional.of(id);
-    }
+   /**
+    * Create NamespaceId from namespace string name (ex: nem or domain.subdom.subdome)
+    *
+    * @param id string representing domain levels
+    */
+   public NamespaceId(String id) {
+      this.id = IdGenerator.generateNamespaceId(id);
+      this.fullName = Optional.of(id);
+   }
 
-    /**
-     * Create NamespaceId from biginteger id
-     *
-     * @param id numeric id
-     */
-    public NamespaceId(BigInteger id) {
-        this.id = id;
-        this.fullName = Optional.empty();
-    }
+   /**
+    * Create NamespaceId from biginteger id
+    *
+    * @param id numeric id
+    */
+   public NamespaceId(BigInteger id) {
+      this.id = id;
+      this.fullName = Optional.empty();
+   }
 
-    /**
-     * Returns namespace biginteger id
-     *
-     * @return namespace biginteger id
-     */
-    public BigInteger getId() {
-        return id;
-    }
+   /**
+    * Returns namespace biginteger id
+    *
+    * @return namespace biginteger id
+    */
+   public BigInteger getId() {
+      return id;
+   }
 
-    /**
-     * Returns optional namespace full name, with subnamespaces if it's the case.
-     *
-     * @return namespace full name
-     */
-    public Optional<String> getFullName() {
-        return fullName;
-    }
+   /**
+    * Returns optional namespace full name, with subnamespaces if it's the case.
+    *
+    * @return namespace full name
+    */
+   public Optional<String> getFullName() {
+      return fullName;
+   }
 
-    /**
-     * Compares namespaceIds for equality.
-     *
-     * @return boolean
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof NamespaceId)) return false;
-        NamespaceId namespaceId1 = (NamespaceId) o;
-        return Objects.equals(id, namespaceId1.id);
-    }
+   @Override
+   public int hashCode() {
+      return Objects.hash(id);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      NamespaceId other = (NamespaceId) obj;
+      return Objects.equals(id, other.id);
+   }
 
    @Override
    public String toString() {

--- a/src/main/java/io/proximax/sdk/model/transaction/Recipient.java
+++ b/src/main/java/io/proximax/sdk/model/transaction/Recipient.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 ProximaX Limited. All rights reserved.
+ * Use of this source code is governed by the Apache 2.0
+ * license that can be found in the LICENSE file.
+ */
+package io.proximax.sdk.model.transaction;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang3.Validate;
+
+import io.proximax.core.utils.Base32Encoder;
+import io.proximax.sdk.model.account.Address;
+import io.proximax.sdk.model.namespace.NamespaceId;
+import io.proximax.sdk.utils.dto.UInt64Utils;
+
+/**
+ * Representation of recipient. This can be either address or namespace which is aliased to the account
+ */
+public class Recipient {
+   private final Optional<Address> address;
+   private final Optional<NamespaceId> namespaceId;
+   
+   /**
+    * Create new instance of recipient. Always either address or namespace ID has to be specified
+    * 
+    * @param address recipient address
+    * @param namespaceId recipient namespace ID which is expected to have an alias to an account
+    */
+   private Recipient(Optional<Address> address, Optional<NamespaceId> namespaceId) {
+      Validate.isTrue(address.isPresent() != namespaceId.isPresent(), "exactly one of address and namespaceId has to be present");
+      this.address = address;
+      this.namespaceId = namespaceId;
+   }
+   
+   /**
+    * create new recipient from the address
+    * 
+    * @param address recipient address
+    */
+   public Recipient(Address address) {
+      this(Optional.of(address), Optional.empty());
+   }
+
+   /**
+    * create new recipient from the namespace ID
+    * 
+    * @param namespaceId recipient namespace ID which is expected to have an alias to an account
+    */
+   public Recipient(NamespaceId namespaceId) {
+      this(Optional.empty(), Optional.of(namespaceId));
+   }
+
+   /**
+    * create new recipient from the address
+    * 
+    * @param address recipient address
+    * @return the recipient
+    */
+   public static Recipient from(Address address) {
+      return new Recipient(address);
+   }
+   
+   /**
+    * create new recipient from the namespace ID
+    * 
+    * @param namespaceId recipient namespace ID which is expected to have an alias to an account
+    * @return the recipient
+    */
+   public static Recipient from(NamespaceId namespaceId) {
+      return new Recipient(namespaceId);
+   }
+   
+   /**
+    * @return the address
+    */
+   public Optional<Address> getAddress() {
+      return address;
+   }
+
+   /**
+    * @return the namespaceId
+    */
+   public Optional<NamespaceId> getNamespaceId() {
+      return namespaceId;
+   }
+
+   /**
+    * get 25 bytes of serialized recipient value
+    * 
+    * @return 25 bytes of address or 25 bytes of namespace ID followed by 0s
+    */
+   public byte[] getBytes() {
+      if (address.isPresent()) {
+         // simply return the address as 25 bytes
+         return Base32Encoder.getBytes(address.get().plain());
+      } else if (namespaceId.isPresent()) {
+         // namespaceId is uint64 (8 bytes) so append 0s to create 25 bytes
+         return ByteBuffer.allocate(25).put((byte)0x91).put(UInt64Utils.getBytes(namespaceId.get().getId())).array();
+      }
+      // this should never happen
+      throw new IllegalStateException("recipient not specified");
+   }
+   
+   @Override
+   public int hashCode() {
+      return Objects.hash(address, namespaceId);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj)
+         return true;
+      if (obj == null)
+         return false;
+      if (getClass() != obj.getClass())
+         return false;
+      Recipient other = (Recipient) obj;
+      return Objects.equals(address, other.address) && Objects.equals(namespaceId, other.namespaceId);
+   }
+
+}

--- a/src/main/java/io/proximax/sdk/model/transaction/TransferTransaction.java
+++ b/src/main/java/io/proximax/sdk/model/transaction/TransferTransaction.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.Validate;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
-import io.proximax.core.utils.Base32Encoder;
 import io.proximax.sdk.gen.buffers.MessageBuffer;
 import io.proximax.sdk.gen.buffers.MosaicBuffer;
 import io.proximax.sdk.gen.buffers.TransferTransactionBuffer;
@@ -32,6 +31,7 @@ import io.proximax.sdk.model.account.Address;
 import io.proximax.sdk.model.account.PublicAccount;
 import io.proximax.sdk.model.blockchain.NetworkType;
 import io.proximax.sdk.model.mosaic.Mosaic;
+import io.proximax.sdk.model.namespace.NamespaceId;
 import io.proximax.sdk.utils.dto.UInt64Utils;
 
 /**
@@ -40,20 +40,20 @@ import io.proximax.sdk.utils.dto.UInt64Utils;
  * @since 1.0
  */
 public class TransferTransaction extends Transaction {
-    private final Address recipient;
+    private final Recipient recipient;
     private final List<Mosaic> mosaics;
     private final Message message;
     private final Schema schema = new TransferTransactionSchema();
 
-    public TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Address recipient, List<Mosaic> mosaics, Message message, String signature, PublicAccount signer, TransactionInfo transactionInfo) {
+    public TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Recipient recipient, List<Mosaic> mosaics, Message message, String signature, PublicAccount signer, TransactionInfo transactionInfo) {
         this(networkType, version, deadline, fee, recipient, mosaics, message, Optional.of(signature), Optional.of(signer), Optional.of(transactionInfo));
     }
 
-    public TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Address recipient, List<Mosaic> mosaics, Message message) {
+    public TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Recipient recipient, List<Mosaic> mosaics, Message message) {
         this(networkType, version, deadline, fee, recipient, mosaics, message, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
-    private TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Address recipient, List<Mosaic> mosaics, Message message, Optional<String> signature, Optional<PublicAccount> signer, Optional<TransactionInfo> transactionInfo) {
+    private TransferTransaction(NetworkType networkType, Integer version, TransactionDeadline deadline, BigInteger fee, Recipient recipient, List<Mosaic> mosaics, Message message, Optional<String> signature, Optional<PublicAccount> signer, Optional<TransactionInfo> transactionInfo) {
         super(TransactionType.TRANSFER, networkType, version, deadline, fee, signature, signer, transactionInfo);
         Validate.notNull(recipient, "Recipient must not be null");
         Validate.notNull(mosaics, "Mosaics must not be null");
@@ -73,16 +73,44 @@ public class TransferTransaction extends Transaction {
      * @param networkType - The network type.
      * @return a TransferTransaction instance
      */
-    public static TransferTransaction create(TransactionDeadline deadline, Address recipient, List<Mosaic> mosaics, Message message, NetworkType networkType) {
-        return new TransferTransaction(networkType, 3, deadline, BigInteger.valueOf(0), recipient, mosaics, message);
+    public static TransferTransaction create(TransactionDeadline deadline, Recipient recipient, List<Mosaic> mosaics, Message message, NetworkType networkType) {
+        return new TransferTransaction(networkType, TransactionVersion.TRANSFER.getValue(), deadline, BigInteger.valueOf(0), recipient, mosaics, message);
     }
 
     /**
-     * Returns address of the recipient.
+     * Create a transfer transaction object for specified Address recipient
      *
-     * @return recipient address
+     * @param deadline    - The deadline to include the transaction.
+     * @param address     - The recipient address of the transaction.
+     * @param mosaics     - The array of mosaics.
+     * @param message     - The transaction message.
+     * @param networkType - The network type.
+     * @return a TransferTransaction instance
      */
-    public Address getRecipient() {
+    public static TransferTransaction create(TransactionDeadline deadline, Address address, List<Mosaic> mosaics, Message message, NetworkType networkType) {
+        return new TransferTransaction(networkType, TransactionVersion.TRANSFER.getValue(), deadline, BigInteger.valueOf(0), Recipient.from(address), mosaics, message);
+    }
+
+    /**
+     * Create a transfer transaction object for specified NamespaceId recipient - it is assumed that given namespace ID has alias to an account
+     *
+     * @param deadline    - The deadline to include the transaction.
+     * @param namespaceId - The recipient namespace of the transaction.
+     * @param mosaics     - The array of mosaics.
+     * @param message     - The transaction message.
+     * @param networkType - The network type.
+     * @return a TransferTransaction instance
+     */
+    public static TransferTransaction create(TransactionDeadline deadline, NamespaceId namespaceId, List<Mosaic> mosaics, Message message, NetworkType networkType) {
+        return new TransferTransaction(networkType, TransactionVersion.TRANSFER.getValue(), deadline, BigInteger.valueOf(0), Recipient.from(namespaceId), mosaics, message);
+    }
+
+    /**
+     * Returns the recipient.
+     *
+     * @return recipient
+     */
+    public Recipient getRecipient() {
         return recipient;
     }
 
@@ -116,7 +144,7 @@ public class TransferTransaction extends Transaction {
         MessageBuffer.startMessageBuffer(builder);
         MessageBuffer.addType(builder, message.getTypeCode());
         MessageBuffer.addPayload(builder, payload);
-        int message = MessageBuffer.endMessageBuffer(builder);
+        int messageVector = MessageBuffer.endMessageBuffer(builder);
 
         // Create Mosaics
         int[] mosaicBuffers = new int[mosaics.size()];
@@ -130,16 +158,32 @@ public class TransferTransaction extends Transaction {
             mosaicBuffers[i] = MosaicBuffer.endMosaicBuffer(builder);
         }
 
-        byte[] address = Base32Encoder.getBytes(getRecipient().plain());
+        // serialize the recipient
+        byte[] recipientBytes = recipient.getBytes();
         // Create Vectors
         int signatureVector = TransferTransactionBuffer.createSignatureVector(builder, new byte[64]);
         int signerVector = TransferTransactionBuffer.createSignerVector(builder, new byte[32]);
         int deadlineVector = TransferTransactionBuffer.createDeadlineVector(builder, UInt64Utils.fromBigInteger(deadlineBigInt));
         int feeVector = TransferTransactionBuffer.createFeeVector(builder, fee);
-        int recipientVector = TransferTransactionBuffer.createRecipientVector(builder, address);
+        int recipientVector = TransferTransactionBuffer.createRecipientVector(builder, recipientBytes);
         int mosaicsVector = TransferTransactionBuffer.createMosaicsVector(builder, mosaicBuffers);
 
-        int size = 120 + 29 + (16 * mosaics.size()) + bytePayload.length;
+        // total size of transaction
+        int size = 
+              // header
+              120 + 
+              // recipient is always 25 bytes
+              25 + 
+              // message size is short
+              2 +
+              // message type byte
+              1 + 
+              // number of mosaics
+              1 + 
+              // each mosaic has id and amount, both 8byte uint64
+              ((8 + 8) * mosaics.size()) + 
+              // number of message bytes
+              bytePayload.length;
 
         TransferTransactionBuffer.startTransferTransactionBuffer(builder);
         TransferTransactionBuffer.addSize(builder, size);
@@ -149,10 +193,11 @@ public class TransferTransaction extends Transaction {
         TransferTransactionBuffer.addType(builder, getType().getValue());
         TransferTransactionBuffer.addFee(builder, feeVector);
         TransferTransactionBuffer.addDeadline(builder, deadlineVector);
+        
         TransferTransactionBuffer.addRecipient(builder, recipientVector);
         TransferTransactionBuffer.addNumMosaics(builder, mosaics.size());
         TransferTransactionBuffer.addMessageSize(builder, bytePayload.length + 1);
-        TransferTransactionBuffer.addMessage(builder, message);
+        TransferTransactionBuffer.addMessage(builder, messageVector);
         TransferTransactionBuffer.addMosaics(builder, mosaicsVector);
 
         int codedTransfer = TransferTransactionBuffer.endTransferTransactionBuffer(builder);

--- a/src/test/java/io/proximax/sdk/infrastructure/TransactionMappingTest.java
+++ b/src/test/java/io/proximax/sdk/infrastructure/TransactionMappingTest.java
@@ -321,7 +321,7 @@ public class TransactionMappingTest extends ResourceBasedTest {
     }
 
     void validateTransferTx(TransferTransaction transaction, JsonObject transactionDTO) {
-        assertEquals(Address.createFromEncoded(getFieldOfObject(transactionDTO, "transaction", "recipient").getAsString()), transaction.getRecipient());
+        assertEquals(Address.createFromEncoded(getFieldOfObject(transactionDTO, "transaction", "recipient").getAsString()), transaction.getRecipient().getAddress().orElseThrow(RuntimeException::new));
 
         JsonArray mosaicsDTO = getFieldOfObject(transactionDTO, "transaction", "mosaics").getAsJsonArray();
         if (mosaicsDTO != null && mosaicsDTO.size() > 0) {

--- a/src/test/java/io/proximax/sdk/model/transaction/RecipientTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/RecipientTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 ProximaX Limited. All rights reserved.
+ * Use of this source code is governed by the Apache 2.0
+ * license that can be found in the LICENSE file.
+ */
+package io.proximax.sdk.model.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.proximax.core.crypto.KeyPair;
+import io.proximax.core.utils.Base32Encoder;
+import io.proximax.sdk.model.account.Account;
+import io.proximax.sdk.model.account.Address;
+import io.proximax.sdk.model.blockchain.NetworkType;
+import io.proximax.sdk.model.namespace.NamespaceId;
+import io.proximax.sdk.utils.dto.UInt64Utils;
+
+/**
+ * Recipient tests
+ */
+class RecipientTest {
+
+   @Test
+   void testForAddress() {
+      Account acct = new Account(new KeyPair(), NetworkType.MAIN_NET);
+      Recipient rcp = new Recipient(acct.getAddress());
+      assertTrue(rcp.getAddress().isPresent());
+      assertTrue(!rcp.getNamespaceId().isPresent());
+      assertEquals(acct.getAddress(), rcp.getAddress().orElseThrow(RuntimeException::new));
+      // test also the static constructor
+      assertEquals(rcp, Recipient.from(acct.getAddress()));
+      
+   }
+
+   @Test
+   void testForNamespace() {
+      NamespaceId nid = new NamespaceId("test.this");
+      Recipient rcp = new Recipient(nid);
+      assertTrue(!rcp.getAddress().isPresent());
+      assertTrue(rcp.getNamespaceId().isPresent());
+      assertEquals(nid, rcp.getNamespaceId().orElseThrow(RuntimeException::new));
+      // test also the static constructor
+      assertEquals(rcp, Recipient.from(nid));
+   }
+
+   @Test
+   void testHashCode() {
+      Recipient r1 = Recipient.from(new NamespaceId("hello"));
+      Recipient r2 = Recipient.from(new NamespaceId("hello"));
+      assertEquals(r1.hashCode(), r2.hashCode());
+   }
+   
+   @Test
+   void testEqualsNamespace() {
+      Recipient r1 = Recipient.from(new NamespaceId("hello"));
+      Recipient r2 = Recipient.from(new NamespaceId("hello"));
+      Recipient r3 = Recipient.from(new NamespaceId("other"));
+      assertEquals(r1, r1);
+      assertEquals(r1, r2);
+      assertNotEquals(r1, null);
+      assertNotEquals(r1, "other class");
+      assertNotEquals(r1, r3);
+   }
+   
+   @Test
+   void testEqualsAddress() {
+      Address addr1 = new Account(new KeyPair(), NetworkType.MAIN_NET).getAddress();
+      Address addr2 = new Account(new KeyPair(), NetworkType.MAIN_NET).getAddress();
+      Recipient r1 = Recipient.from(addr1);
+      Recipient r2 = Recipient.from(addr1);
+      Recipient r3 = Recipient.from(addr2);
+      assertEquals(r1, r1);
+      assertEquals(r1, r2);
+      assertNotEquals(r1, null);
+      assertNotEquals(r1, "other class");
+      assertNotEquals(r1, r3);
+   }
+   
+   @Test
+   void serializeAddress() {
+      Address addr = Address.createFromRawAddress("SARDGFTDLLCB67D4HPGIMIHPNSRYRJRT7DOBGWZY");
+      byte[] addrBytes = Base32Encoder.getBytes(addr.plain());
+      byte[] recipientBytes = Recipient.from(addr).getBytes();
+      assertEquals(25, recipientBytes.length);
+      // test that recipient serializes to expected bytes
+      assertArrayEquals(addrBytes, recipientBytes);
+   }
+   
+   @Test
+   void serializeNamespace() {
+      NamespaceId nsid = new NamespaceId("test");
+      byte[] nsidBytes = UInt64Utils.getBytes(nsid.getId());
+      // test that recipient serializes to expected bytes
+      byte[] recipientBytes = Recipient.from(nsid).getBytes();
+      assertEquals(25, recipientBytes.length);
+      // first byte should be 0x91
+      assertEquals((byte)0x91, recipientBytes[0]);
+      // next 8 bytes should be namespace id
+      for (int i=1; i<9; i++) {
+         assertEquals(nsidBytes[i-1], recipientBytes[i]);
+      }
+      // remaining bytes are 0
+      for (int i=9; i<25; i++) {
+         assertEquals(0, recipientBytes[i]);
+      }
+   }
+   
+}

--- a/src/test/java/io/proximax/sdk/model/transaction/TransferTransactionTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/TransferTransactionTest.java
@@ -61,7 +61,7 @@ class TransferTransactionTest {
         assertTrue(nowSinceNemesis < transferTx.getDeadline().getInstant());
         assertEquals(BigInteger.valueOf(0), transferTx.getFee());
         assertTrue(new Address("SDGLFW-DSHILT-IUHGIB-H5UGX2-VYF5VN-JEKCCD-BR26", NetworkType.MIJIN_TEST)
-                .equals(transferTx.getRecipient()));
+                .equals(transferTx.getRecipient().getAddress().orElseThrow(RuntimeException::new)));
         assertEquals(0, transferTx.getMosaics().size());
         assertNotNull(transferTx.getMessage());
     }


### PR DESCRIPTION
Issue #65 - Use of account alias as transfer recipient

- namespace aliased to account can now be used as a recipient of transfer transaction
- all e2e tests pass