### PR TITLE
fixed initialization of mosaic account property builder

### DIFF
--- a/src/main/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyMosaicTransactionBuilder.java
+++ b/src/main/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyMosaicTransactionBuilder.java
@@ -7,9 +7,9 @@ package io.proximax.sdk.model.transaction.builder;
 
 import java.math.BigInteger;
 
-import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 import io.proximax.sdk.model.transaction.EntityType;
 import io.proximax.sdk.model.transaction.EntityVersion;
+import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 import io.proximax.sdk.model.transaction.UInt64Id;
 
 /**
@@ -18,7 +18,7 @@ import io.proximax.sdk.model.transaction.UInt64Id;
 public class ModifyAccountPropertyMosaicTransactionBuilder extends ModifyAccountPropertyTransactionBuilder<UInt64Id> {
 
    public ModifyAccountPropertyMosaicTransactionBuilder() {
-      super(EntityType.ACCOUNT_PROPERTIES_ADDRESS, EntityVersion.ACCOUNT_PROPERTIES_ADDRESS.getValue());
+      super(EntityType.ACCOUNT_PROPERTIES_MOSAIC, EntityVersion.ACCOUNT_PROPERTIES_MOSAIC.getValue());
    }
 
    @Override

--- a/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyAddressTransactionBuilderTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyAddressTransactionBuilderTest.java
@@ -20,6 +20,7 @@ import io.proximax.sdk.model.account.Address;
 import io.proximax.sdk.model.account.props.AccountPropertyModification;
 import io.proximax.sdk.model.account.props.AccountPropertyType;
 import io.proximax.sdk.model.blockchain.NetworkType;
+import io.proximax.sdk.model.transaction.EntityType;
 import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 
 /**
@@ -37,6 +38,11 @@ class ModifyAccountPropertyAddressTransactionBuilderTest {
       builder.networkType(NETWORK_TYPE);
       builder.deadlineDuration(BigInteger.valueOf(60_000));
       builder.feeCalculationStrategy(FeeCalculationStrategy.MEDIUM);
+   }
+   
+   @Test
+   void checkBuilder() {
+      assertEquals(EntityType.ACCOUNT_PROPERTIES_ADDRESS, builder.getType());
    }
    
    @Test

--- a/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyEntityTransactionBuilderTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyEntityTransactionBuilderTest.java
@@ -17,8 +17,8 @@ import io.proximax.sdk.FeeCalculationStrategy;
 import io.proximax.sdk.model.account.props.AccountPropertyModification;
 import io.proximax.sdk.model.account.props.AccountPropertyType;
 import io.proximax.sdk.model.blockchain.NetworkType;
-import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 import io.proximax.sdk.model.transaction.EntityType;
+import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 
 /**
  * {@link ModifyAccountPropertyEntityTransactionBuilder} tests
@@ -35,6 +35,11 @@ class ModifyAccountPropertyEntityTransactionBuilderTest {
       builder.networkType(NETWORK_TYPE);
       builder.deadlineDuration(BigInteger.valueOf(60_000));
       builder.feeCalculationStrategy(FeeCalculationStrategy.MEDIUM);
+   }
+   
+   @Test
+   void checkBuilder() {
+      assertEquals(EntityType.ACCOUNT_PROPERTIES_ENTITY_TYPE, builder.getType());
    }
    
    @Test

--- a/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyMosaicTransactionBuilderTest.java
+++ b/src/test/java/io/proximax/sdk/model/transaction/builder/ModifyAccountPropertyMosaicTransactionBuilderTest.java
@@ -18,6 +18,7 @@ import io.proximax.sdk.model.account.props.AccountPropertyModification;
 import io.proximax.sdk.model.account.props.AccountPropertyType;
 import io.proximax.sdk.model.blockchain.NetworkType;
 import io.proximax.sdk.model.mosaic.MosaicId;
+import io.proximax.sdk.model.transaction.EntityType;
 import io.proximax.sdk.model.transaction.ModifyAccountPropertyTransaction;
 import io.proximax.sdk.model.transaction.UInt64Id;
 
@@ -39,11 +40,17 @@ class ModifyAccountPropertyMosaicTransactionBuilderTest {
    }
    
    @Test
+   void checkBuilder() {
+      assertEquals(EntityType.ACCOUNT_PROPERTIES_MOSAIC, builder.getType());
+   }
+   
+   @Test
    void test() {
       MosaicId mosid = new MosaicId(BigInteger.ONE);
       AccountPropertyModification<UInt64Id> mod = AccountPropertyModification.add(mosid);
       ModifyAccountPropertyTransaction<UInt64Id> trans = builder.propertyType(AccountPropertyType.ALLOW_MOSAIC).modifications(Arrays.asList(mod)).build();
       
+      assertEquals(EntityType.ACCOUNT_PROPERTIES_MOSAIC, trans.getType());
       assertEquals(AccountPropertyType.ALLOW_MOSAIC, trans.getPropertyType());
       assertEquals(1, trans.getPropertyModifications().size());
       assertEquals(mod, trans.getPropertyModifications().get(0));


### PR DESCRIPTION
fixing issue reported by @thomas-tran 

mosaic account property builder was initialized as address builder. this did not impact functionality because value is not used but it was bug
also enhanced tests to make sure this does not regress in the future