### PR TITLE
Support for unsigned version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Minor release with new features and fixes
 * added MosaicFactory to better support frequent mosaic instantiation and non-standard network currencies
 * added support for exchange transactions
+* added support for unsigned version field for entity info on the chain
 
 ## 0.6.1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://github.com/proximax-storage" target="_blank"><img width="300" srchttps://user-images.githubusercontent.com/29048783/72933958-c8836400-3d30-11ea-99d5-678e20f43e19.png" alt="ProximaX Sirius Blockchain Java SDK"></a></p>
+<p align="center"><a href="https://github.com/proximax-storage" target="_blank"><img width="300" src="https://user-images.githubusercontent.com/29048783/72933958-c8836400-3d30-11ea-99d5-678e20f43e19.png" alt="ProximaX Sirius Blockchain Java SDK"></a></p>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Coverage Status](https://coveralls.io/repos/github/proximax-storage/java-xpx-chain-sdk/badge.svg?branch=master)](https://coveralls.io/github/proximax-storage/java-xpx-chain-sdk?branch=master)

--- a/schemas/swagger/swagger.yaml
+++ b/schemas/swagger/swagger.yaml
@@ -1733,6 +1733,7 @@ components:
         * 0xF243 (62019 decimal) - Mosaic_Alias_Resolution.
     NetworkTypeEnum:
       type: integer
+      format: int64
       description: |
         The entity version. The higher byte represents the network
         identifier:

--- a/src/e2e/java/io/proximax/sdk/E2EBlockchainTest.java
+++ b/src/e2e/java/io/proximax/sdk/E2EBlockchainTest.java
@@ -187,12 +187,19 @@ public class E2EBlockchainTest extends E2EBaseTest {
 
    @Test
    void loadTransactions() {
-      for (int i = 0; i<1000; i++) {
+      // get chain height
+      final long height = blockchainHttp.getBlockchainHeight().blockingFirst().longValue();
+      // go over first 50 blocks
+      for (int i = 0; i<Math.min(height, 50); i++) {
+         loadTransactions(i);
+      }
+      // first 50 blocks got already scanned so start at 50 or last 1000
+      for (long i = Math.max(height-1000, 50l); i<height; i++) {
          loadTransactions(i);
       }
    }
    
-   void loadTransactions(int block) {
+   void loadTransactions(long block) {
       // try to load first 100 transactions and see if we can parse them
       List<Transaction> transactions = blockchainHttp.getBlockTransactions(BigInteger.valueOf(block), new QueryParams(100)).blockingFirst();
       assertTrue(transactions.size() <= 100);

--- a/src/gen/java/io/proximax/sdk/gen/model/BlockDTO.java
+++ b/src/gen/java/io/proximax/sdk/gen/model/BlockDTO.java
@@ -14,20 +14,10 @@
 package io.proximax.sdk.gen.model;
 
 import java.util.Objects;
-import java.util.Arrays;
-import com.google.gson.TypeAdapter;
-import com.google.gson.annotations.JsonAdapter;
+
 import com.google.gson.annotations.SerializedName;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonWriter;
-import io.proximax.sdk.gen.model.BlockDTOAllOf;
-import io.proximax.sdk.gen.model.EntityDTO;
-import io.proximax.sdk.gen.model.EntityTypeEnum;
-import io.proximax.sdk.gen.model.UInt64DTO;
-import io.proximax.sdk.gen.model.VerifiableEntityDTO;
-import io.swagger.annotations.ApiModel;
+
 import io.swagger.annotations.ApiModelProperty;
-import java.io.IOException;
 
 /**
  * BlockDTO
@@ -44,7 +34,7 @@ public class BlockDTO {
 
   public static final String SERIALIZED_NAME_VERSION = "version";
   @SerializedName(SERIALIZED_NAME_VERSION)
-  private Integer version;
+  private Long version;
 
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
@@ -130,7 +120,7 @@ public class BlockDTO {
     this.signer = signer;
   }
 
-  public BlockDTO version(Integer version) {
+  public BlockDTO version(Long version) {
     this.version = version;
     return this;
   }
@@ -140,11 +130,11 @@ public class BlockDTO {
    * @return version
   **/
   @ApiModelProperty(example = "36867", required = true, value = "The entity version. The higher byte represents the network identifier: * 0x68 (MAIN_NET) - Public main network. * 0x98 (TEST_NET) - Public test network. * 0x60 (MIJIN) - Private network. * 0x90 (MIJIN_TEST) - Private test network. ")
-  public Integer getVersion() {
+  public Long getVersion() {
     return version;
   }
 
-  public void setVersion(Integer version) {
+  public void setVersion(Long version) {
     this.version = version;
   }
 

--- a/src/test/java/io/proximax/sdk/model/blockchain/BlockInfoTest.java
+++ b/src/test/java/io/proximax/sdk/model/blockchain/BlockInfoTest.java
@@ -84,7 +84,7 @@ class BlockInfoTest {
       BlockDTO blockDto = new BlockDTO();
       blockDto.setSignature("37351C8244AC166BE6664E3FA954E99A3239AC46E51E2B32CEA1C72DD0851100A7731868E932E1A9BEF8A27D48E1FFEE401E933EB801824373E7537E51733E0F");
       blockDto.setSigner("B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF");
-      blockDto.setVersion(36867);
+      blockDto.setVersion(36867l);
       blockDto.setType(EntityTypeEnum.NUMBER_16705);
       blockDto.setHeight(getUint64Dto(2));
       blockDto.setTimestamp(getUint64Dto(3));


### PR DESCRIPTION
REST API changed to provide version as unsigned integer which violates openapi definition and breaks java SDK

changing the field to long to accommodate the values and support new server